### PR TITLE
fix: correct tilt_interp parameter type in compute_tilt_angles_for_fl…

### DIFF
--- a/floris/core/rotor_velocity.py
+++ b/floris/core/rotor_velocity.py
@@ -152,7 +152,7 @@ def compute_tilt_angles_for_floating_turbines_map(
 
 def compute_tilt_angles_for_floating_turbines(
     tilt_angles: NDArrayFloat,
-    tilt_interp: dict[str, interp1d],
+    tilt_interp: interp1d|None,
     rotor_effective_velocities: NDArrayFloat,
 ) -> NDArrayFloat:
     # Loop over each turbine type given to get tilt angles for all turbines

--- a/floris/core/rotor_velocity.py
+++ b/floris/core/rotor_velocity.py
@@ -152,7 +152,7 @@ def compute_tilt_angles_for_floating_turbines_map(
 
 def compute_tilt_angles_for_floating_turbines(
     tilt_angles: NDArrayFloat,
-    tilt_interp: interp1d|None,
+    tilt_interp: interp1d | None,
     rotor_effective_velocities: NDArrayFloat,
 ) -> NDArrayFloat:
     # Loop over each turbine type given to get tilt angles for all turbines


### PR DESCRIPTION
…oating_turbines

- Change tilt_interp parameter type from dict[str, interp1d] to interp1d|None
- This aligns with the function's actual usage where it expects a single interpolation function or None
