### PR TITLE
Fix NaN turbine power at 0 m/s inflow in Gauss wake models

### DIFF
--- a/floris/core/wake_deflection/gauss.py
+++ b/floris/core/wake_deflection/gauss.py
@@ -157,12 +157,25 @@ class GaussVelocityDeflection(BaseModel):
         ky = self.ka * turbulence_intensity_i + self.kb
         kz = self.ka * turbulence_intensity_i + self.kb
 
-        C0 = 1 - u0 / freestream_velocity
+        # Guard against the zero-inflow case (freestream_velocity == 0), where u0 is
+        # also zero and u0 / freestream_velocity would be 0/0 = NaN. Analytically
+        # u0 / freestream_velocity == sqrt(1 - ct_i), so C0 -> 1 - sqrt(1 - ct_i) in
+        # that limit. Fill the zero-inflow entries with that value.
+        C0_fill = (1 - np.sqrt(1 - ct_i)) * np.ones_like(freestream_velocity)
+        C0 = 1 - np.divide(
+            u0, freestream_velocity, out=1 - C0_fill, where=freestream_velocity > 0.0
+        )
         M0 = C0 * (2 - C0)
         E0 = ne.evaluate("C0 ** 2 - 3 * exp(1.0 / 12.0) * C0 + 3 * exp(1.0 / 3.0)")
 
         # initial Gaussian wake expansion
-        sigma_z0 = ne.evaluate("rotor_diameter_i * 0.5 * sqrt(uR / (freestream_velocity + u0))")
+        # Same zero-inflow guard: uR and u0 are both zero at freestream_velocity == 0,
+        # so the ratio is 0/0 = NaN. A zero inflow produces zero wake, so the initial
+        # wake width is zero there.
+        u_sum = freestream_velocity + u0
+        sigma_z0 = rotor_diameter_i * 0.5 * np.sqrt(
+            np.divide(uR, u_sum, out=np.zeros_like(u_sum), where=u_sum > 0.0)
+        )
         sigma_y0 = sigma_z0 * cosd(yaw_i) * cosd(wind_veer)
 
         # yR = y - y_i
@@ -186,7 +199,20 @@ class GaussVelocityDeflection(BaseModel):
         sigma_z = sigma_z * (x >= x0) + sigma_z0 * (x < x0)
 
         M0_sqrt = np.sqrt(M0)
-        middle_term = np.sqrt(sigma_y * sigma_z / (sigma_y0 * sigma_z0))
+        # sigma_y0 * sigma_z0 is zero at zero inflow (see the guards above), so this
+        # ratio is a 0/0 = NaN there. The resulting far-wake deflection is discarded by
+        # the zero-inflow guard on the returned deflection field below, but compute the
+        # ratio safely to avoid a spurious divide warning.
+        sigma0_prod = sigma_y0 * sigma_z0
+        sigma_prod = sigma_y * sigma_z
+        middle_term = np.sqrt(
+            np.divide(
+                sigma_prod,
+                sigma0_prod,
+                out=np.zeros_like(sigma_prod),
+                where=sigma0_prod > 0.0,
+            )
+        )
         ln_deltaNum = (1.6 + M0_sqrt) * (1.6 * middle_term - M0_sqrt)
         ln_deltaDen = (1.6 - M0_sqrt) * (1.6 * middle_term + M0_sqrt)
 
@@ -201,6 +227,13 @@ class GaussVelocityDeflection(BaseModel):
 
         delta_far_wake = delta_far_wake * (x > x0)
         deflection = delta_near_wake + delta_far_wake
+
+        # At zero inflow (freestream_velocity == 0) the initial wake widths
+        # sigma_y0 and sigma_z0 are zero, which makes the far-wake ratio
+        # sigma_y * sigma_z / (sigma_y0 * sigma_z0) a 0/0 = NaN. There is no wake and
+        # therefore no deflection at zero inflow, so force the deflection to zero there
+        # to keep NaNs from propagating into the velocity-deficit solve.
+        deflection = np.where(freestream_velocity > 0.0, deflection, 0.0)
 
         return deflection
 

--- a/floris/core/wake_velocity/gauss.py
+++ b/floris/core/wake_velocity/gauss.py
@@ -77,7 +77,13 @@ class GaussVelocityDeficit(BaseModel):
         u0 = u_initial * np.sqrt(1 - ct_i)
 
         # Initial lateral bounds
-        sigma_z0 = rotor_diameter_i * 0.5 * np.sqrt(uR / (u_initial + u0))
+        # Guard against the zero-inflow case (u_initial == 0), where uR and u0 are
+        # both zero and the ratio would be 0/0 = NaN. A zero inflow produces zero
+        # wake, so the initial wake width is zero there.
+        u_sum = u_initial + u0
+        sigma_z0 = rotor_diameter_i * 0.5 * np.sqrt(
+            np.divide(uR, u_sum, out=np.zeros_like(u_sum), where=u_sum > 0.0)
+        )
         sigma_y0 = sigma_z0 * cosd(yaw_angle) * cosd(wind_veer)
 
         # Compute the bounds of the near and far wake regions and a mask

--- a/tests/reg_tests/gauss_regression_test.py
+++ b/tests/reg_tests/gauss_regression_test.py
@@ -1034,3 +1034,56 @@ def test_full_flow_solver(sample_inputs_fixture):
     velocities = floris.flow_field.u_sorted
 
     assert_results_arrays(velocities, full_flow_baseline)
+
+
+def test_regression_zero_inflow(sample_inputs_fixture):
+    """
+    Regression test for the zero-inflow (0 m/s) case. At a freestream wind speed of
+    0 m/s the Gauss velocity-deficit and deflection models previously formed the ratio
+    sqrt(uR / (u_initial + u0)) = sqrt(0 / 0) = NaN (and 1 - u0 / freestream_velocity =
+    1 - 0/0 = NaN in the deflection model), poisoning every downstream turbine power
+    with NaN. A zero inflow physically produces zero wake and zero power, so this test
+    asserts the turbine powers are finite and all zero. See issue #1069.
+    """
+    sample_inputs_fixture.core["wake"]["model_strings"]["velocity_model"] = VELOCITY_MODEL
+    sample_inputs_fixture.core["wake"]["model_strings"]["deflection_model"] = DEFLECTION_MODEL
+
+    # Isolate the base Gauss deficit/deflection from the GCH secondary effects
+    sample_inputs_fixture.core["wake"]["enable_secondary_steering"] = False
+    sample_inputs_fixture.core["wake"]["enable_yaw_added_recovery"] = False
+    sample_inputs_fixture.core["wake"]["enable_transverse_velocities"] = False
+
+    sample_inputs_fixture.core["flow_field"]["wind_directions"] = [270.0]
+    sample_inputs_fixture.core["flow_field"]["wind_speeds"] = [0.0]
+    sample_inputs_fixture.core["flow_field"]["turbulence_intensities"] = [0.06]
+
+    floris = Core.from_dict(sample_inputs_fixture.core)
+    floris.initialize_domain()
+    floris.steady_state_atmospheric_condition()
+
+    velocities = floris.flow_field.u
+    turbulence_intensities = floris.flow_field.turbulence_intensity_field
+    air_density = floris.flow_field.air_density
+    yaw_angles = floris.farm.yaw_angles
+    tilt_angles = floris.farm.tilt_angles
+    power_setpoints = floris.farm.power_setpoints
+    awc_modes = floris.farm.awc_modes
+    awc_amplitudes = floris.farm.awc_amplitudes
+
+    turbine_powers = power(
+        velocities,
+        turbulence_intensities,
+        air_density,
+        floris.farm.turbine_power_functions,
+        yaw_angles,
+        tilt_angles,
+        power_setpoints,
+        awc_modes,
+        awc_amplitudes,
+        floris.farm.turbine_tilt_interps,
+        floris.farm.turbine_type_map,
+        floris.farm.turbine_power_thrust_tables,
+    )
+
+    assert not np.isnan(turbine_powers).any()
+    assert np.allclose(turbine_powers, 0.0)


### PR DESCRIPTION
## Summary

At a freestream wind speed of 0 m/s, the Gauss velocity-deficit and deflection models return NaN for every turbine's power. This PR guards the zero-inflow case so a 0 m/s inflow produces zero wake, zero deflection, and zero power, which is the physically correct result.

Fixes #1069

## Root cause (two sites)

The initial Gaussian wake width uses `sqrt(uR / (u_initial + u0))`. Both `uR` and `u0` are proportional to the inflow velocity, so at 0 m/s the ratio is `0 / 0 = NaN`. That NaN flows into `sigma_y0`/`sigma_z0` and then into every downstream turbine power.

- `floris/core/wake_velocity/gauss.py` — `sigma_z0 = rotor_diameter_i * 0.5 * np.sqrt(uR / (u_initial + u0))`
- `floris/core/wake_deflection/gauss.py` — the same `sigma_z0` ratio, plus `C0 = 1 - u0 / freestream_velocity`, which is `1 - 0/0 = NaN` at zero inflow.

Fixing only one site still leaks NaN, because the deflection field is fed back into the velocity-deficit solve.

## The fix

Guard the division at every site so `den > 0` is computed normally and the zero-inflow entries get the physically correct fill:

- **Velocity model:** mask the `sigma_z0` ratio so a zero inflow gives zero wake width.
- **Deflection model:**
  - `C0`: analytically `u0 / freestream_velocity == sqrt(1 - ct)`, so `C0 -> 1 - sqrt(1 - ct)` in the zero-inflow limit. The guard fills that value rather than 0 (the deflection expressions need the correct `C0`/`M0`/`E0` for the `den > 0` case, and this preserves them exactly).
  - `sigma_z0`: mask the ratio (zero wake width at zero inflow).
  - Far-wake width ratio `sigma_y * sigma_z / (sigma_y0 * sigma_z0)`: masked to avoid a spurious divide warning once the widths are zero.
  - The returned deflection field is forced to zero where `freestream_velocity == 0`, since there is no wake and therefore no deflection at zero inflow. This also stops any residual NaN from propagating into the velocity solve.

The guards use `np.divide(num, den, out=..., where=den > 0.0)`, so behavior for all `den > 0` cases is bit-for-bit identical to before; only the previously-NaN zero-inflow entries change.

## Test

Adds `test_regression_zero_inflow` to `tests/reg_tests/gauss_regression_test.py`. It builds the gauss/gauss model with `enable_secondary_steering`, `enable_yaw_added_recovery`, and `enable_transverse_velocities` all disabled, runs at `wind_speeds=[0.0]`, and asserts the turbine powers are finite (`not np.isnan(...).any()`) and all zero (`np.allclose(..., 0.0)`).

- Fails on `main` (all-NaN power).
- Passes with this fix.

## Validation

- New regression test: fails before the fix, passes after.
- `pytest tests/ -k "gauss or velocity or deflection"`: 31 passed.
- `pytest tests/reg_tests/ tests/wake_unit_tests.py`: 50 passed (no regressions on any wake model or normal wind speed).

## AI disclosure

Developed with AI assistance (Claude); I have reviewed, understand, and tested every line.
